### PR TITLE
Use new features from deal.II [WIP]

### DIFF
--- a/bp3/bench.cc
+++ b/bp3/bench.cc
@@ -212,7 +212,7 @@ void test(const unsigned int s,
       laplace_operator.vmult_add(tmp, output);
       deallog << "True residual norm: " << tmp.l2_norm() << std::endl;
     }
-  AssertThrow(solver_control.last_step() == iterations_basic,
+  AssertThrow(std::abs((int)solver_control.last_step() - (int)iterations_basic) < 2,
               ExcMessage("Iteration numbers differ " +
                          std::to_string(solver_control.last_step())
                          + " vs default solver "
@@ -248,7 +248,7 @@ void test(const unsigned int s,
       laplace_operator.vmult_add(tmp, output);
       deallog << "True residual norm: " << tmp.l2_norm() << std::endl;
     }
-  AssertThrow(solver_control.last_step() == iterations_basic,
+  AssertThrow(std::abs((int)solver_control.last_step() - (int)iterations_basic) < 2,
               ExcMessage("Iteration numbers differ " +
                          std::to_string(solver_control.last_step())
                          + " vs default solver "

--- a/bp5/bench.cc
+++ b/bp5/bench.cc
@@ -1,8 +1,6 @@
 
 #include <deal.II/base/timer.h>
 #include <deal.II/distributed/tria.h>
-#include <deal.II/distributed/fully_distributed_tria.h>
-#include <deal.II/distributed/fully_distributed_tria_util.h>
 #include <deal.II/fe/fe_system.h>
 #include <deal.II/fe/fe_q.h>
 #include <deal.II/grid/grid_generator.h>

--- a/bp5/bench.cc
+++ b/bp5/bench.cc
@@ -193,7 +193,7 @@ void test(const unsigned int s,
       laplace_operator.vmult_add(tmp, output);
       deallog << "True residual norm: " << tmp.l2_norm() << std::endl;
     }
-  AssertThrow(true || solver_control.last_step() == iterations_basic,
+  AssertThrow(std::abs( (int)solver_control.last_step() - (int)iterations_basic) < 2,
               ExcMessage("Iteration numbers differ " +
                          std::to_string(solver_control.last_step())
                          + " vs default solver "
@@ -229,7 +229,7 @@ void test(const unsigned int s,
       laplace_operator.vmult_add(tmp, output);
       deallog << "True residual norm: " << tmp.l2_norm() << std::endl;
     }
-  AssertThrow(true || solver_control.last_step() == iterations_basic,
+  AssertThrow(std::abs((int)solver_control.last_step() - (int)iterations_basic) < 2,
               ExcMessage("Iteration numbers differ " +
                          std::to_string(solver_control.last_step())
                          + " vs default solver "

--- a/common_code/create_triangulation.h
+++ b/common_code/create_triangulation.h
@@ -1,6 +1,9 @@
 #ifndef create_triangulation_h_
 #define create_triangulation_h_
 
+#include <deal.II/distributed/fully_distributed_tria.h>
+#include <deal.II/distributed/fully_distributed_tria_util.h>
+
 template<int dim, int spacedim = dim>
 std::shared_ptr<parallel::TriangulationBase<dim, spacedim> > create_triangulation(const unsigned int s, MyManifold<dim> & manifold, const bool use_pft = false)
 {

--- a/common_code/create_triangulation.h
+++ b/common_code/create_triangulation.h
@@ -1,0 +1,66 @@
+#ifndef create_triangulation_h_
+#define create_triangulation_h_
+
+template<int dim, int spacedim = dim>
+std::shared_ptr<parallel::TriangulationBase<dim, spacedim> > create_triangulation(const unsigned int s, MyManifold<dim> & manifold, const bool use_pft = false)
+{
+    
+  std::shared_ptr<parallel::TriangulationBase<dim, spacedim> >  tria_shared;    
+    
+  const unsigned int n_refine = s/3;
+  const unsigned int remainder = s%3;
+  Point<dim> p2;
+  for (unsigned int d=0; d<remainder; ++d)
+    p2[d] = 2;
+  for (unsigned int d=remainder; d<dim; ++d)
+    p2[d] = 1;
+
+  std::vector<unsigned int> subdivisions(dim, 1);
+  for (unsigned int d=0; d<remainder; ++d)
+    subdivisions[d] = 2;
+  
+  if(use_pft == false)
+  {
+    auto tria = new parallel::distributed::Triangulation<dim>(MPI_COMM_WORLD);
+    GridGenerator::subdivided_hyper_rectangle(*tria, subdivisions, Point<dim>(), p2);
+    GridTools::transform(std::bind(&MyManifold<dim>::push_forward, manifold,
+                                   std::placeholders::_1),
+                         *tria);
+    tria->set_all_manifold_ids(1);
+    tria->set_manifold(1, manifold);
+    tria->refine_global(n_refine);
+    
+    tria_shared.reset(tria);
+  }
+  else
+  {
+    dealii::Triangulation<dim> tria_serial;
+    GridGenerator::subdivided_hyper_rectangle(tria_serial, subdivisions, Point<dim>(), p2);
+    GridTools::transform(std::bind(&MyManifold<dim>::push_forward, manifold,
+                                   std::placeholders::_1),
+                         tria_serial);
+    tria_serial.set_all_manifold_ids(1);
+    tria_serial.set_manifold(1, manifold);
+    tria_serial.refine_global(n_refine);
+    
+    {
+      const unsigned int n_procs = Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD);
+      const unsigned int n_cells_per_process = (tria_serial.n_active_cells() + n_procs) / n_procs;
+      
+      // partition equally the active cells
+      for(auto cell : tria_serial.active_cell_iterators ())
+        cell->set_subdomain_id (cell->active_cell_index() / n_cells_per_process);
+    }  
+    
+    const auto cd = parallel::fullydistributed::Utilities::create_construction_data_from_triangulation(tria_serial, MPI_COMM_WORLD);
+    
+    auto tria = new parallel::fullydistributed::Triangulation<dim>(MPI_COMM_WORLD);
+    tria->create_triangulation(cd);
+    
+    tria_shared.reset(tria);
+  }
+  
+  return tria_shared;
+}
+
+#endif

--- a/common_code/renumber_dofs_for_mf.h
+++ b/common_code/renumber_dofs_for_mf.h
@@ -7,15 +7,15 @@
 #include <deal.II/matrix_free/matrix_free.h>
 
 
-template <int dim, typename Number>
+template <int dim, typename Number, typename VectorizedArrayType>
 void renumber_dofs_mf(dealii::DoFHandler<dim> &dof_handler,
                       const dealii::AffineConstraints<double> &constraints,
-                      const typename dealii::MatrixFree<dim,Number>::AdditionalData &mf_data)
+                      const typename dealii::MatrixFree<dim,Number, VectorizedArrayType>::AdditionalData &mf_data)
 {
-  typename dealii::MatrixFree<dim,Number>::AdditionalData my_mf_data =
+  typename dealii::MatrixFree<dim,Number, VectorizedArrayType>::AdditionalData my_mf_data =
     mf_data;
   my_mf_data.initialize_mapping = false;
-  dealii::MatrixFree<dim,Number> matrix_free;
+  dealii::MatrixFree<dim,Number, VectorizedArrayType> matrix_free;
   matrix_free.reinit(dof_handler, constraints,
                      dealii::QGauss<1>(dof_handler.get_fe().degree+1),
                      my_mf_data);

--- a/common_code/renumber_dofs_for_mf.h
+++ b/common_code/renumber_dofs_for_mf.h
@@ -7,7 +7,7 @@
 #include <deal.II/matrix_free/matrix_free.h>
 
 
-template <int dim, typename Number, typename VectorizedArrayType>
+template <int dim, typename Number, typename VectorizedArrayType = dealii::VectorizedArray<Number> >
 void renumber_dofs_mf(dealii::DoFHandler<dim> &dof_handler,
                       const dealii::AffineConstraints<double> &constraints,
                       const typename dealii::MatrixFree<dim,Number, VectorizedArrayType>::AdditionalData &mf_data)


### PR DESCRIPTION
Specifically, following (recently implemented) features are used:
- use `parallel::fullydistributed::Triangulation` 
- explicitly set length vectorization length in (`MatrixFree` and `FEEvaluation`) 

These changes allow to work on subpartitions consisting of only a single cell, which might improve the strong-scaling limit.